### PR TITLE
Added Text When Users Have No Favorites

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@ body {
 
 a {
 	text-decoration: none;
+	color: #0091ff;
 }
 
 body > a > .create-issue {

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,9 +1,12 @@
 <div class="page-container">
 	<h1>Favorite Stops</h1>
-	<% current_user.favorites.each do |stop| %>
-		<%= render "stops/show_with_issues", stop: stop %>
+	<% unless current_user.favorites.empty? %>
+		<% current_user.favorites.each do |stop| %>
+			<%= render "stops/show_with_issues", stop: stop %>
+		<% end %>
+	<% else %>
+		You have no favorite stops! Go to <%= link_to "All Lines", lines_path %> or search for stops to favorite them.
 	<% end %>
-
 </div>
 
 <%= new_issue_button %>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -30,8 +30,8 @@
             <% current_user.favorites.each do |stop| %>
                 <%= render "stops/show_with_issues", stop: stop %>
             <% end %>
-            <% unless current_user.favorites %>
-                <h3>You have not selected any favorites yet!</h3>
+            <% if  current_user.favorites.empty? %>
+                You have no favorite stops! Go to <%= link_to "All Lines", lines_path %> or search for stops to favorite them.
             <% end %>
         </div>
     <% end %>


### PR DESCRIPTION
I've added text to indicate when viewing a page that would list favorites (in particular, the homepage and the favorites page):

Old vs New Homepage:

<img src="https://cloud.githubusercontent.com/assets/3187531/24937447/6235d922-1ef6-11e7-8c17-772d8d2d367d.png" align="left" width="45%">
<img src="https://cloud.githubusercontent.com/assets/3187531/24937446/621e6d14-1ef6-11e7-9b91-4ec46dae5ce8.png" align="left" width="45%">
